### PR TITLE
[update] Add expired method to A0JWT

### DIFF
--- a/JWTDecode/A0JWT.swift
+++ b/JWTDecode/A0JWT.swift
@@ -51,6 +51,11 @@ public class A0JWT: NSObject {
         return self.jwt.expiresAt
     }
 
+    /// value of the `expired` field
+    public var expired: Bool {
+        return self.jwt.expired
+    }
+
     /**
     Creates a new instance of `A0JWT` and decodes the given jwt token.
 


### PR DESCRIPTION
Without it I don't get this method in a bridged header file for use in ObjC project.