### PR TITLE
Rework how claims are decoded

### DIFF
--- a/JWTDecode.playground/Contents.swift
+++ b/JWTDecode.playground/Contents.swift
@@ -48,7 +48,7 @@ do {
 //: ### Custom Claims
 //: If we also have our custom claims we can retrive them calling `claim<T>(name: String) -> T?` where `T` is the value type of the claim, e.g.: a `String`
 
-    let custom: String? = jwt.claim("email")
+    let custom = jwt.claim(name: "email").string
 //: ### Error Handling
 //: If the token is invalid an `NSError` will be thrown
 } catch let error as NSError {

--- a/JWTDecode.playground/contents.xcplayground
+++ b/JWTDecode.playground/contents.xcplayground
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='5.0' target-platform='ios' requires-full-environment='true' display-mode='rendered'>
+<playground version='5.0' target-platform='ios' display-mode='rendered'>
     <timeline fileName='timeline.xctimeline'/>
 </playground>

--- a/JWTDecode.playground/timeline.xctimeline
+++ b/JWTDecode.playground/timeline.xctimeline
@@ -3,37 +3,37 @@
    version = "3.0">
    <TimelineItems>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1536&amp;EndingColumnNumber=13&amp;EndingLineNumber=26&amp;StartingColumnNumber=5&amp;StartingLineNumber=26&amp;Timestamp=463532561.17046"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1540&amp;EndingColumnNumber=13&amp;EndingLineNumber=26&amp;StartingColumnNumber=5&amp;StartingLineNumber=26&amp;Timestamp=493100192.513264"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1536&amp;EndingColumnNumber=18&amp;EndingLineNumber=26&amp;StartingColumnNumber=5&amp;StartingLineNumber=26&amp;Timestamp=463532561.170751"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1540&amp;EndingColumnNumber=18&amp;EndingLineNumber=26&amp;StartingColumnNumber=5&amp;StartingLineNumber=26&amp;Timestamp=493100192.513522"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1536&amp;EndingColumnNumber=17&amp;EndingLineNumber=26&amp;StartingColumnNumber=5&amp;StartingLineNumber=26&amp;Timestamp=463532561.170973"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1540&amp;EndingColumnNumber=17&amp;EndingLineNumber=26&amp;StartingColumnNumber=5&amp;StartingLineNumber=26&amp;Timestamp=493100192.513683"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1536&amp;EndingColumnNumber=17&amp;EndingLineNumber=26&amp;StartingColumnNumber=5&amp;StartingLineNumber=26&amp;Timestamp=463532561.171144"
+         documentLocation = "#CharacterRangeLen=0&amp;CharacterRangeLoc=1540&amp;EndingColumnNumber=17&amp;EndingLineNumber=26&amp;StartingColumnNumber=5&amp;StartingLineNumber=26&amp;Timestamp=493100192.51384"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=1548&amp;EndingColumnNumber=18&amp;EndingLineNumber=26&amp;StartingColumnNumber=5&amp;StartingLineNumber=26&amp;Timestamp=463532561.171315"
+         documentLocation = "#CharacterRangeLen=13&amp;CharacterRangeLoc=1552&amp;EndingColumnNumber=18&amp;EndingLineNumber=26&amp;StartingColumnNumber=5&amp;StartingLineNumber=26&amp;Timestamp=493100192.514013"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=1597&amp;EndingColumnNumber=10&amp;EndingLineNumber=54&amp;StartingColumnNumber=5&amp;StartingLineNumber=54&amp;Timestamp=463532561.171487"
+         documentLocation = "#CharacterRangeLen=1&amp;CharacterRangeLoc=1601&amp;EndingColumnNumber=10&amp;EndingLineNumber=54&amp;StartingColumnNumber=5&amp;StartingLineNumber=54&amp;Timestamp=493100192.51418"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>
       <LoggerValueHistoryTimelineItem
-         documentLocation = "#CharacterRangeLen=12&amp;CharacterRangeLoc=1586&amp;EndingColumnNumber=17&amp;EndingLineNumber=54&amp;StartingColumnNumber=5&amp;StartingLineNumber=54&amp;Timestamp=463532561.171656"
+         documentLocation = "#CharacterRangeLen=12&amp;CharacterRangeLoc=1590&amp;EndingColumnNumber=17&amp;EndingLineNumber=54&amp;StartingColumnNumber=5&amp;StartingLineNumber=54&amp;Timestamp=493100192.514342"
          selectedRepresentationIndex = "0"
          shouldTrackSuperviewWidth = "NO">
       </LoggerValueHistoryTimelineItem>

--- a/JWTDecode/A0JWT.swift
+++ b/JWTDecode/A0JWT.swift
@@ -22,8 +22,9 @@
 
 import Foundation
 
-/// Class to allow Objective-C code to decode a JWT
-public class A0JWT: NSObject {
+/// Decodes a JWT
+@objc(A0JWT)
+public class _JWT: NSObject {
 
     var jwt: JWT
 
@@ -63,8 +64,8 @@ public class A0JWT: NSObject {
 
     :returns: a new instance of `A0JWT` that holds the decode token
     */
-    public class func decode(jwtValue: String) throws -> A0JWT {
+    public class func decode(jwtValue: String) throws -> _JWT {
         let jwt = try DecodedJWT(jwt: jwtValue)
-        return A0JWT(jwt: jwt)
+        return _JWT(jwt: jwt)
     }
 }

--- a/JWTDecode/JWT.swift
+++ b/JWTDecode/JWT.swift
@@ -56,14 +56,29 @@ public protocol JWT {
 }
 
 public extension JWT {
+
     /**
-    Returns a specific claim by its name whose value if of type `T`.
+     Returns a specific claim by its name whose value if of type `T`.
 
-    :param: name of the claim to return
+     - parameter name: name of the claim to return
 
-    :returns: the value of the claim as the generic type `T` if available
-    */
+     - returns: the value of the claim as the generic type `T` if available
+     - warning: This method is deprecated in favor of `claim(name:)`
+     */
+    @available(*, deprecated, message="use claim(name:) -> Claim instead")
     public func claim<T>(name: String) -> T? {
         return self.body[name] as? T
+    }
+
+    /**
+     Return a claim by it's name
+
+     - parameter name: name of the claim in the JWT
+
+     - returns: a claim of the JWT
+     */
+    public func claim(name name: String) -> Claim {
+        let value = self.body[name]
+        return Claim(value: value)
     }
 }

--- a/JWTDecodeTests/JWTDecodeSpec.swift
+++ b/JWTDecodeTests/JWTDecodeSpec.swift
@@ -160,19 +160,52 @@ class JWTDecodeSpec: QuickSpec {
             describe("custom claim") {
 
                 beforeEach {
-                    jwt = jwtWithBody(["sub": NSUUID().UUIDString, "custom_claim": "Shawarma Friday!", "custom_integer_claim": 10])
+                    jwt = jwtWithBody(["sub": NSUUID().UUIDString, "custom_claim": "Shawarma Friday!", "custom_integer_claim": 10, "custom_double_claim": 3.4, "custom_double_string_claim": "1.3"])
                 }
 
-                it("should return custom claims") {
-                    let stringValue: String? = jwt.claim("custom_claim")
-                    expect(stringValue).to(equal("Shawarma Friday!"))
-                    let integerValue: Int? = jwt.claim("custom_integer_claim")
-                    expect(integerValue).to(equal(10))
+                it("should return string claim") {
+                    let claim = jwt.claim(name: "custom_claim")
+                    expect(claim.string) == "Shawarma Friday!"
+                    expect(claim.array) == ["Shawarma Friday!"]
+                    expect(claim.integer).to(beNil())
+                    expect(claim.date).to(beNil())
+                    expect(claim.double).to(beNil())
                 }
 
-                it("should return nil when claim is not present") {
-                    let unknownClaim: String? = jwt.claim("missing_claim")
-                    expect(unknownClaim).to(beNil())
+                it("should return integer claim") {
+                    let claim = jwt.claim(name: "custom_integer_claim")
+                    expect(claim.string).to(beNil())
+                    expect(claim.array) == []
+                    expect(claim.integer) == 10
+                    expect(claim.double) == 10.0
+                    expect(claim.date) == NSDate(timeIntervalSince1970: 10)
+                }
+
+                it("should return double claim") {
+                    let claim = jwt.claim(name: "custom_double_claim")
+                    expect(claim.string).to(beNil())
+                    expect(claim.array) == []
+                    expect(claim.integer) == 3
+                    expect(claim.double) == 3.4
+                    expect(claim.date) == NSDate(timeIntervalSince1970: 3.4)
+                }
+
+                it("should return double as string claim") {
+                    let claim = jwt.claim(name: "custom_double_string_claim")
+                    expect(claim.string) == "1.3"
+                    expect(claim.array) == ["1.3"]
+                    expect(claim.integer).to(beNil())
+                    expect(claim.double) == 1.3
+                    expect(claim.date) == NSDate(timeIntervalSince1970: 1.3)
+                }
+
+                it("should return no value when clain is not present") {
+                    let unknownClaim = jwt.claim(name: "missing_claim")
+                    expect(unknownClaim.array) == []
+                    expect(unknownClaim.string).to(beNil())
+                    expect(unknownClaim.integer).to(beNil())
+                    expect(unknownClaim.double).to(beNil())
+                    expect(unknownClaim.date).to(beNil())
                 }
             }
         }


### PR DESCRIPTION
Add Claim object to handle conversion of claims to common types

The `Claim` object will convert a claim of the jwt to the following values:

- [String]
- String
- Int: from a numeric value or a string
- Double: from a numeric value or a string
- NSDate: parsed as a Double and then treated as NSTimeInterval since 1970

Closes #23 