### PR TITLE
Add dictionary accessor for claim value

### DIFF
--- a/JWTDecode/JWTDecode.swift
+++ b/JWTDecode/JWTDecode.swift
@@ -122,6 +122,11 @@ public struct Claim {
         }
         return nil
     }
+
+        /// value of the claim as [String: Any]
+    public var dictionary: [String: Any]? {
+        return value as? [String: Any]
+    }
 }
 
 private func base64UrlDecode(_ value: String) -> Data? {

--- a/JWTDecodeTests/JWTDecodeSpec.swift
+++ b/JWTDecodeTests/JWTDecodeSpec.swift
@@ -162,7 +162,7 @@ class JWTDecodeSpec: QuickSpec {
             describe("custom claim") {
 
                 beforeEach {
-                    token = jwt(withBody: ["sub": UUID().uuidString, "custom_claim": "Shawarma Friday!", "custom_integer_claim": 10, "custom_double_claim": 3.4, "custom_double_string_claim": "1.3"])
+                    token = jwt(withBody: ["sub": UUID().uuidString, "custom_claim": "Shawarma Friday!", "custom_integer_claim": 10, "custom_double_claim": 3.4, "custom_double_string_claim": "1.3", "custom_dictionary_claim": ["key": "value"]])
                 }
 
                 it("should return string claim") {
@@ -172,6 +172,7 @@ class JWTDecodeSpec: QuickSpec {
                     expect(claim.integer).to(beNil())
                     expect(claim.date).to(beNil())
                     expect(claim.double).to(beNil())
+                    expect(claim.dictionary).to(beNil())
                 }
 
                 it("should return integer claim") {
@@ -181,6 +182,7 @@ class JWTDecodeSpec: QuickSpec {
                     expect(claim.integer) == 10
                     expect(claim.double) == 10.0
                     expect(claim.date) == Date(timeIntervalSince1970: 10)
+                    expect(claim.dictionary).to(beNil())
                 }
 
                 it("should return double claim") {
@@ -190,6 +192,7 @@ class JWTDecodeSpec: QuickSpec {
                     expect(claim.integer) == 3
                     expect(claim.double) == 3.4
                     expect(claim.date) == Date(timeIntervalSince1970: 3.4)
+                    expect(claim.dictionary).to(beNil())
                 }
 
                 it("should return double as string claim") {
@@ -199,6 +202,17 @@ class JWTDecodeSpec: QuickSpec {
                     expect(claim.integer).to(beNil())
                     expect(claim.double) == 1.3
                     expect(claim.date) == Date(timeIntervalSince1970: 1.3)
+                    expect(claim.dictionary).to(beNil())
+                }
+
+                it("should return dictionary claim") {
+                    let claim = token.claim(name: "custom_dictionary_claim")
+                    expect(claim.string).to(beNil())
+                    expect(claim.array).to(beNil())
+                    expect(claim.integer).to(beNil())
+                    expect(claim.double).to(beNil())
+                    expect(claim.date).to(beNil())
+                    expect(claim.dictionary as? [String: String]) == ["key": "value"]
                 }
 
                 it("should return no value when clain is not present") {
@@ -208,6 +222,7 @@ class JWTDecodeSpec: QuickSpec {
                     expect(unknownClaim.integer).to(beNil())
                     expect(unknownClaim.double).to(beNil())
                     expect(unknownClaim.date).to(beNil())
+                    expect(unknownClaim.dictionary).to(beNil())
                 }
             }
         }


### PR DESCRIPTION
This PR adds `dictionary` accessor for `Claim`'s `value`. It returns `value` as `[String: Any]?`.