### PR TITLE
Added 'brew update' to pre run.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ machine:
 
 dependencies:
   pre:
+    - brew update
     - brew install swiftlint
     - grep -lR "shouldUseLaunchSchemeArgsEnv" *.* --null | xargs -0 sed -i '' -e 's/shouldUseLaunchSchemeArgsEnv = "YES"/shouldUseLaunchSchemeArgsEnv = "YES" codeCoverageEnabled = "YES"/g'
   post:


### PR DESCRIPTION
Added explicit 'brew update' to pre-run to prevent Ruby from 'sticking' on a portable version < 2.3.

See discussion [here](https://discuss.circleci.com/t/homebrew-must-be-run-under-ruby-2-3-runtimeerror/17232/4).