### PR TITLE
Added method to check if a JWT will be expired x seconds from now.

### DIFF
--- a/JWTDecode/JWT.swift
+++ b/JWTDecode/JWT.swift
@@ -52,6 +52,9 @@ public protocol JWT {
 
     /// Checks if the token is currently expired using the `exp` claim. If there is no claim present it will deem the token not expired
     var expired: Bool { get }
+
+    /// Check if the token will be expired at a given time offset (in seconds) from now.
+    func willBeExpired(in seconds: TimeInterval) -> Bool
 }
 
 public extension JWT {

--- a/JWTDecode/JWTDecode.swift
+++ b/JWTDecode/JWTDecode.swift
@@ -69,6 +69,14 @@ struct DecodedJWT: JWT {
         }
         return date.compare(Date()) != ComparisonResult.orderedDescending
     }
+
+    func willBeExpired(in seconds: TimeInterval) -> Bool {
+        guard let date = self.expiresAt else {
+            return false
+        }
+
+        return date < Date().addingTimeInterval(seconds)
+    }
 }
 
 /**

--- a/JWTDecodeTests/JWTDecodeSpec.swift
+++ b/JWTDecodeTests/JWTDecodeSpec.swift
@@ -36,11 +36,19 @@ class JWTDecodeSpec: QuickSpec {
             it("should tell a jwt is not expired") {
                 expect(nonExpiredJWT().expired).to(beFalsy())
             }
-
+            
             it("should tell a jwt is expired with a close enough timestamp") {
                 expect(jwtThatExpiresAt(date: Date()).expired).to(beTruthy())
             }
 
+            it("should tell a jwt is not expired at the time offset from now") {
+                expect(jwtThatExpiresAt(date: Date() + TimeInterval(120)).willBeExpired(in: TimeInterval(60))).to(beFalsy())
+            }
+            
+            it("should tell a jwt is expired at the time offset from now") {
+                expect(jwtThatExpiresAt(date: Date() + TimeInterval(60)).willBeExpired(in: TimeInterval(120))).to(beTruthy())
+            }
+            
             it("should obtain payload") {
                 let token = jwt(withBody: ["sub": "myid", "name": "Shawarma Monk"])
                 let payload = token.body as! [String: String]


### PR DESCRIPTION
Seems like most other JWT libs out there have this functionality and I need it in a project I'm working on so I thought I might as well implement it.

This PR adds a method called `willBeExpired` to the JWT protocol that takes a TimeInterval in seconds. If the current time + timeinterval is after the expiration of the JWT then it will return true signifying the token will be expired by that time. Else it will return false.

I added test cases for this and they pass.
