### PR TITLE
Multiple Swift version support in CocoaPods

### DIFF
--- a/JWTDecode.podspec
+++ b/JWTDecode.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'JWTDecode/*.swift'
 
-   s.swift_version = '4.0'
+   s.swift_version = '5.0'
 end

--- a/JWTDecode.podspec
+++ b/JWTDecode.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'JWTDecode/*.swift'
 
-   s.swift_version = '5.0'
+   s.swift_versions = ['4.0', '4.1', '4.2', '5.0']
 end


### PR DESCRIPTION
one missing swift 5.0 update following https://github.com/auth0/JWTDecode.swift/pull/88

### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed