### PR TITLE
Release 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.3.1](https://github.com/auth0/JWTDecode.swift/tree/2.3.1) (2019-09-24)
+[Full Changelog](https://github.com/auth0/JWTDecode.swift/compare/2.3.0...2.3.1)
+
+**Added**
+- Multiple Swift version support in CocoaPods [\#94](https://github.com/auth0/JWTDecode.swift/pull/94) ([ericbuehl](https://github.com/ericbuehl))
+
 ## [2.3.0](https://github.com/auth0/JWTDecode.swift/tree/2.3.0) (2019-05-06)
 [Full Changelog](https://github.com/auth0/JWTDecode.swift/compare/2.2.0...2.3.0)
 

--- a/JWTDecode/Info.plist
+++ b/JWTDecode/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/JWTDecodeTests/Info.plist
+++ b/JWTDecodeTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.3.0</string>
+	<string>2.3.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
**Added**
- Multiple Swift version support in CocoaPods [\#94](https://github.com/auth0/JWTDecode.swift/pull/94) ([ericbuehl](https://github.com/ericbuehl))
