### PR TITLE
Release 2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [2.6.1](https://github.com/auth0/JWTDecode.swift/tree/2.6.1) (2021-06-07)
+[Full Changelog](https://github.com/auth0/JWTDecode.swift/compare/2.6.0...2.6.1)
+
+**Changed**
+- Make test dependencies not resolve when installing with SPM [SDK-2599] [\#125](https://github.com/auth0/JWTDecode.swift/pull/125) ([Widcket](https://github.com/Widcket))
+
 ## [2.6.0](https://github.com/auth0/JWTDecode.swift/tree/2.6.0) (2021-02-02)
 [Full Changelog](https://github.com/auth0/JWTDecode.swift/compare/2.5.0...2.6.0)
 

--- a/JWTDecode/Info.plist
+++ b/JWTDecode/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.6.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/JWTDecodeTests/Info.plist
+++ b/JWTDecodeTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.0</string>
+	<string>2.6.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
**Changed**
- Make test dependencies not resolve when installing with SPM [SDK-2599] [\#125](https://github.com/auth0/JWTDecode.swift/pull/125) ([Widcket](https://github.com/Widcket))


[SDK-2599]: https://auth0team.atlassian.net/browse/SDK-2599