### PR TITLE
Use the new release automation solution

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,0 +1,8 @@
+{
+    "files": {
+        "JWTDecode/Info.plist": [],
+        "README.md": ["~> {MAJOR}.{MINOR}"]
+    },
+    "postbump": "bundle update",
+    "prefixVersion": false
+}

--- a/JWTDecodeTests/Info.plist
+++ b/JWTDecodeTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.1</string>
+	<string>0.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -55,13 +55,6 @@ platform :ios do
     test
   end
   
-  desc "Releases the library to Cocoapods & Github Releases and updates README/CHANGELOG"
-  desc "You need to specify the type of release with the `bump` parameter with the values [major|minor|patch]"
-  lane :release_prepare do |options|
-    release_options = {repository: 'JWTDecode.swift', xcodeproj: 'JWTDecode.xcodeproj', target: 'JWTDecode-iOS'}.merge(options)
-    prepare_release release_options
-  end
-
   desc "Performs the prepared release by creating a tag and pusing to remote"
   lane :release_perform do
     perform_release target: 'JWTDecode-iOS'
@@ -72,4 +65,3 @@ platform :ios do
     publish_release repository: 'JWTDecode.swift'
   end
 end
-


### PR DESCRIPTION
### Changes

This PR adds support for the new release automation CLI.

Previously, we were using a [custom Fastlane plugin](https://github.com/auth0/fastlane-plugin-auth0_shipper) for bumping the version number and updating the Changelog. To bump the version, that plugin [uses](https://github.com/auth0/fastlane-plugin-auth0_shipper/blob/master/lib/fastlane/plugin/auth0_shipper/actions/prepare_release_action.rb#L24) the `IncrementVersionNumberAction` action from Fastlane. That action [uses](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/increment_version_number.rb#L71) the `agvtool new-marketing-version` command to bump the version number. That command will bump the version number in every `Info.plist` file it can find, regardless of whether it's actually necessary or not:

<img width="698" alt="Screen Shot 2021-08-23 at 16 43 33" src="https://user-images.githubusercontent.com/5055789/130509944-86694ec0-03cc-43c1-a7e8-ae3c388a8d5c.png">

See [a previous release](https://github.com/auth0/JWTDecode.swift/pull/126/files) of this SDK:
 
<img width="886" alt="Screen Shot 2021-08-23 at 16 25 57" src="https://user-images.githubusercontent.com/5055789/130510002-3be60dd4-7c96-46db-bf52-1a3a41aee1af.png">

It's bumping the version number of the **test target**, even though it's not necessary; only the **library target's** version number needs to be bumped (`JWTDecode/Info.plist`).

So this PR sets up the version number replacement for `JWTDecode/Info.plist` in the `.shiprc` file, and sets the version number of the test target to be `0.1.0`. That means that going forward, each release PR will only be bumping the version number in `JWTDecode/Info.plist`.

Additionally, this PR removes the now-unused Fastlane task.

### Testing

[ ] This change adds unit test coverage (or why not)
[ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

[ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[ ] All existing and new tests complete without errors