### PR TITLE
Remove agvtool from podspec

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,6 +1,7 @@
 {
     "files": {
         "JWTDecode/Info.plist": [],
+        "JWTDecode.podspec": [],
         "README.md": ["~> {MAJOR}.{MINOR}"]
     },
     "postbump": "bundle update",

--- a/JWTDecode.podspec
+++ b/JWTDecode.podspec
@@ -1,7 +1,6 @@
-version = `agvtool mvers -terse1`.strip
 Pod::Spec.new do |s|
   s.name             = "JWTDecode"
-  s.version          = version
+  s.version          = '2.6.2'
   s.summary          = "A JSON Web Token decoder for iOS, macOS, tvOS"
   s.description      = <<-DESC
                         Decode a JWT to retrieve it's payload and also check for its expiration. 
@@ -21,5 +20,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'JWTDecode/*.swift'
 
-  s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3']
+  s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3', '5.4']
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -46,13 +46,6 @@ Cocoapods library lint
 fastlane ios ci
 ```
 Runs all the tests in a CI environment
-### ios release_prepare
-```
-fastlane ios release_prepare
-```
-Releases the library to Cocoapods & Github Releases and updates README/CHANGELOG
-
-You need to specify the type of release with the `bump` parameter with the values [major|minor|patch]
 ### ios release_perform
 ```
 fastlane ios release_perform
@@ -66,6 +59,6 @@ Releases the library to CocoaPods trunk & Github Releases
 
 ----
 
-This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
 The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
### Changes

The podspec relied on `agvtool` to get the current version number. That tool looks up the relevant key in every `Info.plist` file it can find:

<img width="693" alt="Screen Shot 2021-09-01 at 16 31 51" src="https://user-images.githubusercontent.com/5055789/131732566-2868a5ef-3c24-4587-b888-a513b4cce023.png">

This PR does away with `agvtool` and just uses the release CLI to bump the version number in the podspec. 

### References

Related to https://github.com/auth0/JWTDecode.swift/pull/128

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed