### PR TITLE
Add supported Plattforms to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,8 +5,11 @@ import PackageDescription
 let package = Package(
     name: "JWTDecode",
     platforms: [
-        .iOS(.v9), .watchOS(.v2), .macOS(.v10_11), .tvOS(.v9)
-    ], 
+        .iOS(.v9),
+        .macOS(.v10_11),
+        .watchOS(.v2),
+        .tvOS(.v9)
+    ],
     products: [
         .library(
             name: "JWTDecode",

--- a/Package.swift
+++ b/Package.swift
@@ -4,14 +4,16 @@ import PackageDescription
 
 let package = Package(
     name: "JWTDecode",
-    products: [
+    platforms: [
+        .iOS(.v9), .watchOS(.v2), .macOS(.v10_11), .tvOS(.v9)
+    ], products: [
         .library(
             name: "JWTDecode",
             targets: ["JWTDecode"])
     ],
     dependencies: [
-         .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
-         .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0"))
+        .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
+        .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0"))
     ],
     targets: [
         .target(
@@ -21,5 +23,4 @@ let package = Package(
         .testTarget(
             name: "JWTDecode.swiftTests",
             dependencies: ["JWTDecode", "Quick", "Nimble"])
-    ]
-)
+    ])

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ let package = Package(
     name: "JWTDecode",
     platforms: [
         .iOS(.v9), .watchOS(.v2), .macOS(.v10_11), .tvOS(.v9)
-    ], products: [
+    ], 
+    products: [
         .library(
             name: "JWTDecode",
             targets: ["JWTDecode"])


### PR DESCRIPTION
### Issue

The Package.swift was lacking the actually supported plattforms / versions. This PR alignes the Package.swift with the provided podspec file.