### PR TITLE
Updated dependencies

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 3.0
+github "Quick/Quick" ~> 4.0
 github "Quick/Nimble" ~> 9.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v9.0.0"
-github "Quick/Quick" "v3.0.0"
+github "Quick/Nimble" "v9.2.1"
+github "Quick/Quick" "v4.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'fastlane'
-gem 'semantic',  '~> 1.5'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["JWTDecode"])
     ],
     dependencies: [
-        .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
+        .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "4.0.0")),
         .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0"))
     ],
     targets: [

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,3 @@
-require('semantic')
-
 opt_out_usage
 
 default_platform :ios


### PR DESCRIPTION
### Changes

This PR updates [Quick](https://github.com/Quick/Quick) to version [4.0.0](https://github.com/Quick/Quick/releases/tag/v4.0.0), and removes the `semantic` gem that was unused.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed