### PR TITLE
Migrate to XCFrameworks [SDK-2801]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,7 @@ commands:
             - << parameters.scheme >>-v1-gems-{{ checksum "Gemfile.lock" }}
       - run:
           name: Install gems
-          command: |
-            bundle check || bundle install --without=development
+          command: bundle check || bundle install --without=development
       - save_cache:
           key: << parameters.scheme >>-v1-gems-{{ checksum "Gemfile.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,13 @@
 version: 2.1
 
 executors:
-  job-environment:
+  macos-executor:
+    parameters:
+      xcode:
+        type: string
     shell: /bin/bash --login -eo pipefail
+    macos:
+      xcode: << parameters.xcode >>
     environment:
       LC_ALL: en_US.UTF-8
       LANG: en_US.UTF-8
@@ -14,100 +19,119 @@ executors:
       HOMEBREW_NO_AUTO_UPDATE: 1
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       FL_OUTPUT_DIR: output
+      FASTLANE_EXPLICIT_OPEN_SIMULATOR: 2
 
 commands:
   prepare:
     parameters:
-      ruby:
+      scheme:
         type: string
-        default: "2.7.1p83"
-      xcode:
-        type: string
-        default: "11.7.0"
     steps:
       - restore_cache:
           keys:
-          - jwtdecode-swift-gems-{{ checksum "Gemfile.lock" }}
-          - jwtdecode-swift-gems-
-      - run: |
-          echo "ruby-<< parameters.ruby >>" > ~/.ruby-version
-          bundle check || bundle install --without=development
+            - << parameters.scheme >>-v1-gems-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Install gems
+          command: |
+            bundle check || bundle install --without=development
       - save_cache:
-          key: jwtdecode-swift-gems-{{ checksum "Gemfile.lock" }}
+          key: << parameters.scheme >>-v1-gems-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
-      - run: |
-          brew install swiftlint
-          grep -lR "shouldUseLaunchSchemeArgsEnv" *.* --null | xargs -0 sed -i '' -e 's/shouldUseLaunchSchemeArgsEnv = "YES"/shouldUseLaunchSchemeArgsEnv = "YES" codeCoverageEnabled = "YES"/g'
+      - run:
+          name: Install Swiftlint
+          command: brew install swiftlint
+      - run:
+          name: Save Xcode version
+          command: xcodebuild -version | tee .xcode-version
       - restore_cache:
           keys:
-            - jwtdecode-swift-carthage-{ checksum "Cartfile.resolved" }}-<< parameters.xcode >>
-            - jwtdecode-swift-carthage-{ checksum "Cartfile.resolved" }}
-            - jwtdecode-swift-carthage-
-      - run: carthage bootstrap --no-use-binaries --cache-builds
+            - << parameters.scheme >>-v3-carthage-{{ checksum "Cartfile.resolved" }}-{{ checksum ".xcode-version" }}
+      - run:
+          name: Install dependencies
+          command: carthage bootstrap --use-xcframeworks --no-use-binaries --cache-builds
       - save_cache:
-          key: jwtdecode-swift-carthage-{ checksum "Cartfile.resolved" }}-<< parameters.xcode >>
+          key: << parameters.scheme >>-v3-carthage-{{ checksum "Cartfile.resolved" }}-{{ checksum ".xcode-version" }}
           paths:
             - Carthage/Build
   test-ios:
-    steps: 
-      - run: bundle exec fastlane ios ci
-  pod-lint:
+    parameters:
+      scheme:
+        type: string
     steps:
-      - run: bundle exec fastlane ios pod_lint
-  send-coverage-report:
-    steps:
-      - run: bash <(curl -s https://codecov.io/bash) -J 'JWTDecode'
-  test-macos:
-    steps: 
-      - run: |
-          security create-keychain -p circle cikeychain
-          security list-keychains -d user -s "/Users/distiller/Library/Keychains/xcode.keychain-db" /Users/distiller/Library/Keychains/cikeychain-db
-          security default-keychain -s /Users/distiller/Library/Keychains/cikeychain-db
-          security unlock-keychain -p circle "/Users/distiller/Library/Keychains/cikeychain-db"
-          xcodebuild test -scheme JWTDecode-OSX -destination 'platform=macOS,arch=x86_64' | xcpretty
-          swift test
-  test-tvos:
-    steps: 
-      - run: xcodebuild test -scheme JWTDecode-tvOS -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
-
-jobs:
-  build-and-test-iOS-swift-5_2:
-    executor: job-environment
-    environment:
-      FASTLANE_EXPLICIT_OPEN_SIMULATOR: 2
-    macos:
-      xcode: 11.7.0
-    steps:
-      - checkout
-      - prepare
-      - test-ios
-      - send-coverage-report
-      - pod-lint
+      - run:
+          name: Run iOS tests
+          command: bundle exec fastlane ios ci
+      - run:
+          name: Upload coverage report
+          command: bash <(curl -s https://codecov.io/bash) -J '<< parameters.scheme >>'
+      - run:
+          name: Run pod lib lint
+          command: bundle exec fastlane ios pod_lint
       - store_test_results:
           path: output/scan
       - store_artifacts:
           path: output
-  build-and-test-macOS-swift-5_2:
-    executor: job-environment
-    macos:
-      xcode: 11.7.0
+  test-macos:
+    parameters:
+      scheme:
+        type: string
+    steps:
+      - run:
+          name: Run macOS tests
+          command: |
+            xcodebuild test -scheme << parameters.scheme >>-OSX -destination 'platform=macOS,arch=x86_64' | xcpretty
+            swift test
+  test-tvos:
+    parameters:
+      scheme:
+        type: string
+    steps:
+      - run:
+          name: Run tvOS tests
+          command: xcodebuild test -scheme << parameters.scheme >>-tvOS -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
+
+jobs:
+  build-and-test:
+    parameters:
+      platform:
+        type: string
+      xcode:
+        type: string
+      scheme:
+        type: string
+    executor:
+      name: macos-executor
+      xcode: << parameters.xcode >>
     steps:
       - checkout
-      - prepare
-      - test-macos
-  build-and-test-tvOS-swift-5_2:
-    executor: job-environment
-    macos:
-      xcode: 11.7.0
-    steps:
-      - checkout
-      - prepare
-      - test-tvos
+      - prepare:
+          scheme: << parameters.scheme >>
+      - when:
+          condition:
+            equal: [ios, << parameters.platform >>]
+          steps:
+            - test-ios:
+                scheme: << parameters.scheme >>
+      - when:
+          condition:
+            equal: [macos, << parameters.platform >>]
+          steps:
+            - test-macos:
+                scheme: << parameters.scheme >>
+      - when:
+          condition:
+            equal: [tvos, << parameters.platform >>]
+          steps:
+            - test-tvos:
+                scheme: << parameters.scheme >>
 
 workflows:
   build:
     jobs:
-      -  build-and-test-iOS-swift-5_2
-      -  build-and-test-macOS-swift-5_2
-      -  build-and-test-tvOS-swift-5_2
+      - build-and-test:
+          scheme: "JWTDecode"
+          matrix:
+            parameters:
+              platform: ["ios", "macos", "tvos"]
+              xcode: ["13.0.0", "12.5.1"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ commands:
           command: xcodebuild test -scheme << parameters.scheme >>-tvOS -destination 'platform=tvOS Simulator,name=Apple TV' | xcpretty
 
 jobs:
-  build-and-test:
+  build-test:
     parameters:
       platform:
         type: string
@@ -128,7 +128,7 @@ jobs:
 workflows:
   build:
     jobs:
-      - build-and-test:
+      - build-test:
           scheme: "JWTDecode"
           matrix:
             parameters:

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'fastlane'
+gem "cocoapods"
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)
-
-gem "cocoapods", ">= 1.9.0.beta.3"

--- a/JWTDecode.podspec
+++ b/JWTDecode.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'JWTDecode/*.swift'
 
-  s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3', '5.4']
+  s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5']
 end

--- a/JWTDecode.xcodeproj/project.pbxproj
+++ b/JWTDecode.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -26,18 +26,23 @@
 		5C1B5D8D238711B10076E46B /* JWTDecodeSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EA5A02237EBBCA00264C01 /* JWTDecodeSpec.swift */; };
 		5C1B5D8E238711B30076E46B /* JWTHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EA5A04237EBBCB00264C01 /* JWTHelper.swift */; };
 		5C1B5D8F238711B40076E46B /* TokenValidatorsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57EA5A03237EBBCB00264C01 /* TokenValidatorsSpec.swift */; };
-		5F0068EE1B3B46240048928E /* JWTDecode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F0068E21B3B46240048928E /* JWTDecode.framework */; };
-		5F0069141B3B532E0048928E /* JWTDecode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F0069091B3B532E0048928E /* JWTDecode.framework */; };
+		5CE9C9FB26FC1E8F005A75FA /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CE9C9F926FC1E8F005A75FA /* Nimble.xcframework */; };
+		5CE9C9FC26FC1E8F005A75FA /* Quick.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CE9C9FA26FC1E8F005A75FA /* Quick.xcframework */; };
+		5CE9CA0126FC1ED3005A75FA /* Nimble.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5CE9C9F926FC1E8F005A75FA /* Nimble.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5CE9CA0226FC1ED5005A75FA /* Quick.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5CE9C9FA26FC1E8F005A75FA /* Quick.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5CE9CA0326FC1FF5005A75FA /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CE9C9F926FC1E8F005A75FA /* Nimble.xcframework */; };
+		5CE9CA0426FC1FF5005A75FA /* Quick.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CE9C9FA26FC1E8F005A75FA /* Quick.xcframework */; };
+		5CE9CA0526FC1FFB005A75FA /* Nimble.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5CE9C9F926FC1E8F005A75FA /* Nimble.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5CE9CA0626FC1FFB005A75FA /* Quick.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5CE9C9FA26FC1E8F005A75FA /* Quick.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5CE9CA0726FC2009005A75FA /* Nimble.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CE9C9F926FC1E8F005A75FA /* Nimble.xcframework */; };
+		5CE9CA0826FC2009005A75FA /* Quick.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5CE9C9FA26FC1E8F005A75FA /* Quick.xcframework */; };
+		5CE9CA0926FC200D005A75FA /* Nimble.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5CE9C9F926FC1E8F005A75FA /* Nimble.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5CE9CA0A26FC200D005A75FA /* Quick.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5CE9C9FA26FC1E8F005A75FA /* Quick.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		5CE9CA0C26FC22F8005A75FA /* JWTDecode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F0068E21B3B46240048928E /* JWTDecode.framework */; };
+		5CE9CA0D26FC23B1005A75FA /* JWTDecode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F0069091B3B532E0048928E /* JWTDecode.framework */; };
+		5CE9CA0E26FC23B8005A75FA /* JWTDecode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 918A8E5B1D63D2E1001F787B /* JWTDecode.framework */; };
 		5F00693E1B3C7B930048928E /* JWTDecode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0069021B3B511F0048928E /* JWTDecode.swift */; };
 		5F0069411B3C828F0048928E /* A0JWTDecodeSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 5F0069401B3C828F0048928E /* A0JWTDecodeSpec.m */; };
-		5F2614D81C05FE850068DE71 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F2614CD1C05FDDE0068DE71 /* Quick.framework */; };
-		5F2614D91C05FE850068DE71 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F2614CE1C05FDDE0068DE71 /* Nimble.framework */; };
-		5F2614DA1C05FE880068DE71 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F2614D41C05FE720068DE71 /* Quick.framework */; };
-		5F2614DB1C05FE880068DE71 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5F2614D51C05FE720068DE71 /* Nimble.framework */; };
-		5F2614DD1C05FEB90068DE71 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F2614CD1C05FDDE0068DE71 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5F2614DE1C05FEB90068DE71 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F2614CE1C05FDDE0068DE71 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5F2614E01C05FEE20068DE71 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F2614D41C05FE720068DE71 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5F2614E11C05FEE20068DE71 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5F2614D51C05FE720068DE71 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5F8B43691B9F99B400A0D5AE /* A0JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8B43681B9F99B400A0D5AE /* A0JWT.swift */; };
 		5F8B436A1B9F99B400A0D5AE /* A0JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F8B43681B9F99B400A0D5AE /* A0JWT.swift */; };
 		5FE49DCD1BA0D5F700DE57D3 /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCC1BA0D5F700DE57D3 /* JWT.swift */; };
@@ -48,11 +53,6 @@
 		918A8E651D63D2F7001F787B /* JWTDecode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0069021B3B511F0048928E /* JWTDecode.swift */; };
 		918A8E661D63D2FB001F787B /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCC1BA0D5F700DE57D3 /* JWT.swift */; };
 		918A8E671D63D2FE001F787B /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCF1BA0D66F00DE57D3 /* Errors.swift */; };
-		918A8E711D63D4E5001F787B /* JWTDecode.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 918A8E5B1D63D2E1001F787B /* JWTDecode.framework */; };
-		918A8E7D1D63D86E001F787B /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 918A8E7A1D63D86E001F787B /* Nimble.framework */; };
-		918A8E7F1D63D86E001F787B /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 918A8E7B1D63D86E001F787B /* Quick.framework */; };
-		918A8E821D63DB42001F787B /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 918A8E7B1D63D86E001F787B /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		918A8E831D63DB4D001F787B /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 918A8E7A1D63D86E001F787B /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E390BAD32288E6AF00780D6C /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCF1BA0D66F00DE57D3 /* Errors.swift */; };
 		E390BAD42288E6AF00780D6C /* TokenValidators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B75B0CF21B6B1250065A681 /* TokenValidators.swift */; };
 		E390BAD52288E6AF00780D6C /* ValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB694FF21BEB53B00280BA2 /* ValidationError.swift */; };
@@ -97,8 +97,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				5F2614DD1C05FEB90068DE71 /* Quick.framework in CopyFiles */,
-				5F2614DE1C05FEB90068DE71 /* Nimble.framework in CopyFiles */,
+				5CE9CA0126FC1ED3005A75FA /* Nimble.xcframework in CopyFiles */,
+				5CE9CA0226FC1ED5005A75FA /* Quick.xcframework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -108,8 +108,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				5F2614E01C05FEE20068DE71 /* Quick.framework in CopyFiles */,
-				5F2614E11C05FEE20068DE71 /* Nimble.framework in CopyFiles */,
+				5CE9CA0526FC1FFB005A75FA /* Nimble.xcframework in CopyFiles */,
+				5CE9CA0626FC1FFB005A75FA /* Quick.xcframework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -119,8 +119,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				918A8E821D63DB42001F787B /* Quick.framework in CopyFiles */,
-				918A8E831D63DB4D001F787B /* Nimble.framework in CopyFiles */,
+				5CE9CA0926FC200D005A75FA /* Nimble.xcframework in CopyFiles */,
+				5CE9CA0A26FC200D005A75FA /* Quick.xcframework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -133,6 +133,8 @@
 		5B75B0CF21B6B1250065A681 /* TokenValidators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenValidators.swift; sourceTree = "<group>"; };
 		5B75B0D321B7DC4A0065A681 /* ValidatorJWT.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidatorJWT.swift; sourceTree = "<group>"; };
 		5BB694FF21BEB53B00280BA2 /* ValidationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationError.swift; sourceTree = "<group>"; };
+		5CE9C9F926FC1E8F005A75FA /* Nimble.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Nimble.xcframework; path = Carthage/Build/Nimble.xcframework; sourceTree = "<group>"; };
+		5CE9C9FA26FC1E8F005A75FA /* Quick.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Quick.xcframework; path = Carthage/Build/Quick.xcframework; sourceTree = "<group>"; };
 		5F0068E21B3B46240048928E /* JWTDecode.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JWTDecode.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5F0068E61B3B46240048928E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		5F0068ED1B3B46240048928E /* JWTDecode-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "JWTDecode-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -180,9 +182,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5F2614D91C05FE850068DE71 /* Nimble.framework in Frameworks */,
-				5F2614D81C05FE850068DE71 /* Quick.framework in Frameworks */,
-				5F0068EE1B3B46240048928E /* JWTDecode.framework in Frameworks */,
+				5CE9C9FB26FC1E8F005A75FA /* Nimble.xcframework in Frameworks */,
+				5CE9C9FC26FC1E8F005A75FA /* Quick.xcframework in Frameworks */,
+				5CE9CA0C26FC22F8005A75FA /* JWTDecode.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -197,9 +199,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5F2614DB1C05FE880068DE71 /* Nimble.framework in Frameworks */,
-				5F2614DA1C05FE880068DE71 /* Quick.framework in Frameworks */,
-				5F0069141B3B532E0048928E /* JWTDecode.framework in Frameworks */,
+				5CE9CA0326FC1FF5005A75FA /* Nimble.xcframework in Frameworks */,
+				5CE9CA0426FC1FF5005A75FA /* Quick.xcframework in Frameworks */,
+				5CE9CA0D26FC23B1005A75FA /* JWTDecode.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -214,9 +216,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				918A8E7D1D63D86E001F787B /* Nimble.framework in Frameworks */,
-				918A8E7F1D63D86E001F787B /* Quick.framework in Frameworks */,
-				918A8E711D63D4E5001F787B /* JWTDecode.framework in Frameworks */,
+				5CE9CA0726FC2009005A75FA /* Nimble.xcframework in Frameworks */,
+				5CE9CA0826FC2009005A75FA /* Quick.xcframework in Frameworks */,
+				5CE9CA0E26FC23B8005A75FA /* JWTDecode.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -233,6 +235,8 @@
 		57F02C0B237ED39800D45E14 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5CE9C9F926FC1E8F005A75FA /* Nimble.xcframework */,
+				5CE9C9FA26FC1E8F005A75FA /* Quick.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -920,7 +924,8 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -943,7 +948,11 @@
 				INFOPLIST_FILE = JWTDecode/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.JWTDecode;
 				PRODUCT_MODULE_NAME = JWTDecode;
 				PRODUCT_NAME = JWTDecode;
@@ -968,12 +977,17 @@
 				INFOPLIST_FILE = JWTDecode/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.JWTDecode;
 				PRODUCT_MODULE_NAME = JWTDecode;
 				PRODUCT_NAME = JWTDecode;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 			};
@@ -986,16 +1000,16 @@
 				CLANG_ENABLE_CODE_COVERAGE = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = JWTDecodeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.auth0.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "JWTDecodeTests/JWTDecode-iOSTests-Bridging-Header.h";
@@ -1012,16 +1026,17 @@
 				CLANG_ENABLE_CODE_COVERAGE = YES;
 				CLANG_ENABLE_MODULES = YES;
 				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/iOS",
-				);
 				INFOPLIST_FILE = JWTDecodeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.auth0.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OBJC_BRIDGING_HEADER = "JWTDecodeTests/JWTDecode-iOSTests-Bridging-Header.h";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 			};
@@ -1044,7 +1059,11 @@
 				);
 				INFOPLIST_FILE = JWTDecode/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.JWTDecode;
 				PRODUCT_MODULE_NAME = JWTDecode;
@@ -1068,14 +1087,19 @@
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = JWTDecode/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.JWTDecode;
 				PRODUCT_MODULE_NAME = JWTDecode;
 				PRODUCT_NAME = JWTDecode;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 			};
@@ -1088,16 +1112,16 @@
 				CLANG_ENABLE_CODE_COVERAGE = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = JWTDecodeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.auth0.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1113,12 +1137,12 @@
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				CLANG_ENABLE_CODE_COVERAGE = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/Mac",
-				);
 				INFOPLIST_FILE = JWTDecodeTests/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@loader_path/../Frameworks",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.auth0.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1141,7 +1165,11 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = JWTDecode/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.JWTDecode;
 				PRODUCT_MODULE_NAME = JWTDecode;
 				PRODUCT_NAME = JWTDecode;
@@ -1166,7 +1194,11 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = JWTDecode/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.JWTDecode;
 				PRODUCT_MODULE_NAME = JWTDecode;
 				PRODUCT_NAME = JWTDecode;
@@ -1186,12 +1218,12 @@
 				CLANG_ENABLE_CODE_COVERAGE = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
 				INFOPLIST_FILE = JWTDecode/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.auth0.JWTDecode-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
@@ -1208,16 +1240,17 @@
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ENABLE_CODE_COVERAGE = YES;
 				DEVELOPMENT_TEAM = "";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)/Carthage/Build/tvOS",
-				);
 				INFOPLIST_FILE = JWTDecode/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = "com.auth0.JWTDecode-tvOSTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2,3";
@@ -1240,7 +1273,11 @@
 				INFOPLIST_FILE = JWTDecode/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.JWTDecode;
 				PRODUCT_MODULE_NAME = JWTDecode;
 				PRODUCT_NAME = JWTDecode;
@@ -1268,13 +1305,18 @@
 				INFOPLIST_FILE = JWTDecode/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.JWTDecode;
 				PRODUCT_MODULE_NAME = JWTDecode;
 				PRODUCT_NAME = JWTDecode;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 4;

--- a/JWTDecode.xcodeproj/xcshareddata/xcschemes/JWTDecode-iOS.xcscheme
+++ b/JWTDecode.xcodeproj/xcshareddata/xcschemes/JWTDecode-iOS.xcscheme
@@ -40,7 +40,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5F0068E11B3B46240048928E"
+            BuildableName = "JWTDecode.framework"
+            BlueprintName = "JWTDecode-iOS"
+            ReferencedContainer = "container:JWTDecode.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -53,17 +63,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "5F0068E11B3B46240048928E"
-            BuildableName = "JWTDecode.framework"
-            BlueprintName = "JWTDecode-iOS"
-            ReferencedContainer = "container:JWTDecode.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -84,8 +83,6 @@
             ReferencedContainer = "container:JWTDecode.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Version](https://img.shields.io/cocoapods/v/JWTDecode.svg?style=flat-square)](https://cocoadocs.org/docsets/JWTDecode)
 [![License](https://img.shields.io/cocoapods/l/JWTDecode.svg?style=flat-square)](https://cocoadocs.org/docsets/JWTDecode)
 [![Platform](https://img.shields.io/cocoapods/p/JWTDecode.svg?style=flat-square)](https://cocoadocs.org/docsets/JWTDecode)
-![Swift 5.3](https://img.shields.io/badge/Swift-5.3-orange.svg?style=flat-square)
+![Swift 5.5](https://img.shields.io/badge/Swift-5.5-orange.svg?style=flat-square)
 
 This library will help you check [JWT](https://jwt.io/) payload
 
@@ -25,7 +25,7 @@ This library will help you check [JWT](https://jwt.io/) payload
 ## Requirements
 
 - iOS 9+ / macOS 10.11+ / tvOS 9.0+ / watchOS 2.0+
-- Xcode 11.4+ / 12.x
+- Xcode 12.x / 13.x
 - Swift 4.x / 5.x
 
 ## Installation
@@ -50,7 +50,7 @@ If you are using [Carthage](https://github.com/Carthage/Carthage), add the follo
 github "auth0/JWTDecode.swift" ~> 2.6
 ```
 
-Then run `carthage bootstrap`.
+Then run `carthage bootstrap --use-xcframeworks`.
 
 > For more information about Carthage usage, check [their official documentation](https://github.com/Carthage/Carthage#if-youre-building-for-ios-tvos-or-watchos).
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,23 +8,13 @@ platform :ios do
     setup_circle_ci
   end
 
-  desc "Installs dependencies using Carthage"
-  lane :dependencies do |options|
-    action = options[:action]
-    carthage(use_binaries: false, command: action, cache_builds: true, platform: 'iOS')
-  end
-
-  desc "Bootstrap the development environment"
-  lane :bootstrap do
-    dependencies
-  end
-
   desc "Run code linter"
   lane :lint do
   	swiftlint(
   		mode: :lint,
    		config_file: '.swiftlint.yml',
-      reporter: 'emoji'
+      reporter: 'emoji',
+      raise_if_swiftlint_error: true
   	)
   end
 

--- a/fastlane/Scanfile
+++ b/fastlane/Scanfile
@@ -1,4 +1,4 @@
 scheme "JWTDecode-iOS"
-devices ["iPhone 11"]
+devices ["iPhone 12"]
 
 clean true


### PR DESCRIPTION
### Changes

This PR migrates the library Xcode project to use XCFramework dependencies instead of fat frameworks, updating the CI and Fastlane config accordingly as well.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed