### PR TITLE
Combine the `release_perform` and `release_publish` Fastlane lanes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,3 @@
-opt_out_usage
-
 default_platform :ios
 
 platform :ios do
@@ -43,13 +41,9 @@ platform :ios do
     test
   end
   
-  desc "Performs the prepared release by creating a tag and pusing to remote"
-  lane :release_perform do
+  desc "Tags the release and pushes the Podspec to CocoaPods"
+  lane :release do
     perform_release target: 'JWTDecode-iOS'
-  end
-
-  desc "Releases the library to CocoaPods trunk & Github Releases"
-  lane :release_publish do
     publish_release repository: 'JWTDecode.swift'
   end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -16,16 +16,6 @@ or alternatively using `brew install fastlane`
 
 # Available Actions
 ## iOS
-### ios dependencies
-```
-fastlane ios dependencies
-```
-Installs dependencies using Carthage
-### ios bootstrap
-```
-fastlane ios bootstrap
-```
-Bootstrap the development environment
 ### ios lint
 ```
 fastlane ios lint
@@ -46,16 +36,11 @@ Cocoapods library lint
 fastlane ios ci
 ```
 Runs all the tests in a CI environment
-### ios release_perform
+### ios release
 ```
-fastlane ios release_perform
+fastlane ios release
 ```
-Performs the prepared release by creating a tag and pusing to remote
-### ios release_publish
-```
-fastlane ios release_publish
-```
-Releases the library to CocoaPods trunk & Github Releases
+Tags the release and pushes the Podspec to CocoaPods
 
 ----
 


### PR DESCRIPTION
### Changes

Currently, performing a release once the release PR has been merged involves invoking two commands:

- `bundle exec fastlane ios release_perform`. This creates the tag and pushes it to the remote.
- `bundle exec fastlane ios release_publish`. This publishes the pod spec to the Cocoapods trunk.

This is a leftover from the old release scripts, before the new release CLI, as the process had multiple steps. This PR simplifies the new process by merging the `release_perform` and `release_publish` steps into a single `release` step (lane).

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed