### PR TITLE
Bump Quick and Nimble

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 4.0
-github "Quick/Nimble" ~> 9.0
+github "Quick/Quick" ~> 5.0
+github "Quick/Nimble" ~> 10.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v9.2.1"
-github "Quick/Quick" "v4.0.0"
+github "Quick/Nimble" "v10.0.0"
+github "Quick/Quick" "v5.0.1"

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
             targets: ["JWTDecode"])
     ],
     dependencies: [
-        .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "4.0.0")),
-        .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0"))
+        .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "5.0.0")),
+        .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "10.0.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
### Changes

This PR bumps Quick to v5.0.1. and Nimble to v10.0.0 to fix an issue with Xcode 13.3: https://github.com/Quick/Quick/issues/1123

The test code was updated accordingly, given the breaking changes in Quick and Nimble.

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed