### PR TITLE
Drop support for old Swift versions [SDK-3394]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,4 +133,4 @@ workflows:
           matrix:
             parameters:
               platform: ["ios", "macos", "tvos"]
-              xcode: ["13.0.0", "12.5.1"]
+              xcode: ["13.0.0"]

--- a/JWTDecode.podspec
+++ b/JWTDecode.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
 
   s.source_files = 'JWTDecode/*.swift'
 
-  s.swift_versions = ['4.0', '4.1', '4.2', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5']
+  s.swift_versions = ['5.5', '5.6']
 end

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.5
 
 import PackageDescription
 
@@ -23,7 +23,8 @@ let package = Package(
         .target(
             name: "JWTDecode",
             dependencies: [],
-            path: "JWTDecode"),
+            path: "JWTDecode",
+            exclude: ["Info.plist"]),
         .testTarget(
             name: "JWTDecode.swiftTests",
             dependencies: ["JWTDecode", "Quick", "Nimble"])

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This library will help you check [JWT](https://jwt.io/) payload
 
 - iOS 9+ / macOS 10.11+ / tvOS 9.0+ / watchOS 2.0+
 - Xcode 12.x / 13.x
-- Swift 4.x / 5.x
+- Swift 5.5+
 
 ## Installation
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,7 +1,0 @@
-import XCTest
-
-import JWTDecode_swiftTests
-
-var tests = [XCTestCaseEntry]()
-tests += JWTDecode_swiftTests.allTests()
-XCTMain(tests)

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -4,7 +4,16 @@ As expected with a major release, JWTDecode.swift v3 contains breaking changes. 
 
 ## Table of Contents
 
+- [**Supported Languages**](#supported-languages)
+  + [Swift](#swift)
+- [**Supported Platform Versions**](#supported-platform-versions)
+- [**Types Removed**](#types-removed)
+
 ## Supported Languages
+
+### Swift
+
+The minimum supported Swift version is now **5.5**.
 
 ## Supported Platform Versions
 


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

The minimum Swift version supported was raised to 5.5.

### References

<img width="732" alt="Screen Shot 2022-06-01 at 21 58 09" src="https://user-images.githubusercontent.com/5055789/171525365-b2a730a7-e5f3-4186-8f6f-73c6271ae4ef.png">

https://developer.apple.com/news/?id=2t1chhp3

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed