### PR TITLE
Rename `DecodeError` and error case

### DIFF
--- a/JWTDecode.playground/Contents.swift
+++ b/JWTDecode.playground/Contents.swift
@@ -59,7 +59,7 @@ do {
     _ = jwt["custom"].rawValue as? [Int]
 
     // Error Handling
-    // If the JWT is malformed the `decode(jwt:)` function will throw a `DecodeError`.
-} catch let error as DecodeError {
+    // If the JWT is malformed the `decode(jwt:)` function will throw a `JWTDecodeError`.
+} catch let error as JWTDecodeError {
     error
 }

--- a/JWTDecode.podspec
+++ b/JWTDecode.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
   s.name             = 'JWTDecode'
   s.version          = '2.6.3'
-  s.summary          = 'A JSON Web Token decoder for iOS, macOS, tvOS, and watchOS'
+  s.summary          = 'A JWT decoder for iOS, macOS, tvOS, and watchOS'
   s.description      = <<-DESC
                         Easily decode a JWT and access the claims it contains. 
-                        > This library doesn't validate the JWT. Any well formed JWT can be decoded from Base64URL.
+                        > This library doesn't validate the JWT. Any well-formed JWT can be decoded from Base64URL.
                         DESC
   s.homepage         = 'https://github.com/auth0/JWTDecode.swift'
   s.license          = 'MIT'

--- a/JWTDecode.xcodeproj/project.pbxproj
+++ b/JWTDecode.xcodeproj/project.pbxproj
@@ -32,12 +32,12 @@
 		5F00693E1B3C7B930048928E /* JWTDecode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0069021B3B511F0048928E /* JWTDecode.swift */; };
 		5FE49DCD1BA0D5F700DE57D3 /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCC1BA0D5F700DE57D3 /* JWT.swift */; };
 		5FE49DCE1BA0D5F700DE57D3 /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCC1BA0D5F700DE57D3 /* JWT.swift */; };
-		5FE49DD01BA0D66F00DE57D3 /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCF1BA0D66F00DE57D3 /* DecodeError.swift */; };
-		5FE49DD11BA0D66F00DE57D3 /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCF1BA0D66F00DE57D3 /* DecodeError.swift */; };
+		5FE49DD01BA0D66F00DE57D3 /* JWTDecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCF1BA0D66F00DE57D3 /* JWTDecodeError.swift */; };
+		5FE49DD11BA0D66F00DE57D3 /* JWTDecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCF1BA0D66F00DE57D3 /* JWTDecodeError.swift */; };
 		918A8E651D63D2F7001F787B /* JWTDecode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0069021B3B511F0048928E /* JWTDecode.swift */; };
 		918A8E661D63D2FB001F787B /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCC1BA0D5F700DE57D3 /* JWT.swift */; };
-		918A8E671D63D2FE001F787B /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCF1BA0D66F00DE57D3 /* DecodeError.swift */; };
-		E390BAD32288E6AF00780D6C /* DecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCF1BA0D66F00DE57D3 /* DecodeError.swift */; };
+		918A8E671D63D2FE001F787B /* JWTDecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCF1BA0D66F00DE57D3 /* JWTDecodeError.swift */; };
+		E390BAD32288E6AF00780D6C /* JWTDecodeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCF1BA0D66F00DE57D3 /* JWTDecodeError.swift */; };
 		E390BAD82288E6AF00780D6C /* JWTDecode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F0069021B3B511F0048928E /* JWTDecode.swift */; };
 		E390BAD92288E6AF00780D6C /* JWT.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FE49DCC1BA0D5F700DE57D3 /* JWT.swift */; };
 /* End PBXBuildFile section */
@@ -130,7 +130,7 @@
 		5F2614D41C05FE720068DE71 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = SOURCE_ROOT; };
 		5F2614D51C05FE720068DE71 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = SOURCE_ROOT; };
 		5FE49DCC1BA0D5F700DE57D3 /* JWT.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWT.swift; sourceTree = "<group>"; };
-		5FE49DCF1BA0D66F00DE57D3 /* DecodeError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DecodeError.swift; sourceTree = "<group>"; };
+		5FE49DCF1BA0D66F00DE57D3 /* JWTDecodeError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JWTDecodeError.swift; sourceTree = "<group>"; };
 		918A8E5B1D63D2E1001F787B /* JWTDecode.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JWTDecode.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		918A8E6C1D63D4E5001F787B /* JWTDecode-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "JWTDecode-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		918A8E7A1D63D86E001F787B /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = SOURCE_ROOT; };
@@ -239,8 +239,8 @@
 			isa = PBXGroup;
 			children = (
 				5F0069021B3B511F0048928E /* JWTDecode.swift */,
+				5FE49DCF1BA0D66F00DE57D3 /* JWTDecodeError.swift */,
 				5FE49DCC1BA0D5F700DE57D3 /* JWT.swift */,
-				5FE49DCF1BA0D66F00DE57D3 /* DecodeError.swift */,
 				5F0068E51B3B46240048928E /* Supporting Files */,
 			);
 			path = JWTDecode;
@@ -673,7 +673,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5FE49DD01BA0D66F00DE57D3 /* DecodeError.swift in Sources */,
+				5FE49DD01BA0D66F00DE57D3 /* JWTDecodeError.swift in Sources */,
 				5C1B5D86238711610076E46B /* JWTDecode.swift in Sources */,
 				5FE49DCD1BA0D5F700DE57D3 /* JWT.swift in Sources */,
 			);
@@ -692,7 +692,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5FE49DD11BA0D66F00DE57D3 /* DecodeError.swift in Sources */,
+				5FE49DD11BA0D66F00DE57D3 /* JWTDecodeError.swift in Sources */,
 				5F00693E1B3C7B930048928E /* JWTDecode.swift in Sources */,
 				5FE49DCE1BA0D5F700DE57D3 /* JWT.swift in Sources */,
 			);
@@ -711,7 +711,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				918A8E671D63D2FE001F787B /* DecodeError.swift in Sources */,
+				918A8E671D63D2FE001F787B /* JWTDecodeError.swift in Sources */,
 				918A8E651D63D2F7001F787B /* JWTDecode.swift in Sources */,
 				918A8E661D63D2FB001F787B /* JWT.swift in Sources */,
 			);
@@ -730,7 +730,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E390BAD32288E6AF00780D6C /* DecodeError.swift in Sources */,
+				E390BAD32288E6AF00780D6C /* JWTDecodeError.swift in Sources */,
 				E390BAD82288E6AF00780D6C /* JWTDecode.swift in Sources */,
 				E390BAD92288E6AF00780D6C /* JWT.swift in Sources */,
 			);

--- a/JWTDecode/JWTDecode.swift
+++ b/JWTDecode/JWTDecode.swift
@@ -7,7 +7,7 @@ import Foundation
 /// ```
 ///
 /// - Parameter jwt: JWT string value to decode.
-/// - Throws: A ``DecodeError`` error if the JWT cannot be decoded.
+/// - Throws: A ``JWTDecodeError`` error if the JWT cannot be decoded.
 /// - Returns: A ``JWT`` value.
 /// - Important: This method doesn't validate the JWT. Any well-formed JWT can be decoded from Base64URL.
 public func decode(jwt: String) throws -> JWT {
@@ -24,7 +24,7 @@ struct DecodedJWT: JWT {
     init(jwt: String) throws {
         let parts = jwt.components(separatedBy: ".")
         guard parts.count == 3 else {
-            throw DecodeError.invalidPartCount(jwt, parts.count)
+            throw JWTDecodeError.invalidPartCount(jwt, parts.count)
         }
 
         self.header = try decodeJWTPart(parts[0])
@@ -129,11 +129,11 @@ private func base64UrlDecode(_ value: String) -> Data? {
 
 private func decodeJWTPart(_ value: String) throws -> [String: Any] {
     guard let bodyData = base64UrlDecode(value) else {
-        throw DecodeError.invalidBase64Url(value)
+        throw JWTDecodeError.invalidBase64URL(value)
     }
 
     guard let json = try? JSONSerialization.jsonObject(with: bodyData, options: []), let payload = json as? [String: Any] else {
-        throw DecodeError.invalidJSON(value)
+        throw JWTDecodeError.invalidJSON(value)
     }
 
     return payload

--- a/JWTDecode/JWTDecodeError.swift
+++ b/JWTDecode/JWTDecodeError.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 /// A decoding error due to a malformed JWT.
-public enum DecodeError: LocalizedError, CustomDebugStringConvertible {
+public enum JWTDecodeError: LocalizedError, CustomDebugStringConvertible {
     /// When either the header or body parts cannot be Base64URL-decoded.
-    case invalidBase64Url(String)
+    case invalidBase64URL(String)
 
     /// When either the decoded header or body is not a valid JSON object.
     case invalidJSON(String)
@@ -30,7 +30,7 @@ public enum DecodeError: LocalizedError, CustomDebugStringConvertible {
             return "Failed to parse JSON from Base64URL value \(value)."
         case .invalidPartCount(let jwt, let parts):
             return "The JWT \(jwt) has \(parts) parts when it should have 3 parts."
-        case .invalidBase64Url(let value):
+        case .invalidBase64URL(let value):
             return "Failed to decode Base64URL value \(value)."
         }
     }

--- a/JWTDecodeTests/JWTDecodeSpec.swift
+++ b/JWTDecodeTests/JWTDecodeSpec.swift
@@ -51,7 +51,7 @@ class JWTDecodeSpec: QuickSpec {
                 let jwtString = "\(invalidChar).BODY.SIGNATURE"
                 expect { try decode(jwt: jwtString) }
                     .to(throwError { (error: Error) in
-                        expect(error).to(beDecodeErrorWithCode(.invalidBase64Url(invalidChar)))
+                        expect(error).to(beJWTDecodeError(.invalidBase64URL(invalidChar)))
                     })
             }
 
@@ -59,7 +59,7 @@ class JWTDecodeSpec: QuickSpec {
                 let jwtString = "HEADER.BODY.SIGNATURE"
                 expect { try decode(jwt: jwtString) }
                     .to(throwError { (error: Error) in
-                        expect(error).to(beDecodeErrorWithCode(.invalidJSON("HEADER")))
+                        expect(error).to(beJWTDecodeError(.invalidJSON("HEADER")))
                     })
             }
 
@@ -67,7 +67,7 @@ class JWTDecodeSpec: QuickSpec {
                 let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdWIifQ"
                 expect { try decode(jwt: jwtString) }
                     .to(throwError { (error: Error) in
-                        expect(error).to(beDecodeErrorWithCode(.invalidPartCount(jwtString, 2)))
+                        expect(error).to(beJWTDecodeError(.invalidPartCount(jwtString, 2)))
                     })
             }
 
@@ -255,17 +255,17 @@ class JWTDecodeSpec: QuickSpec {
     }
 }
 
-public func beDecodeErrorWithCode(_ code: DecodeError) -> Predicate<Error> {
-     return Predicate<Error>.define("be decode error with code <\(code)>") { expression, failureMessage -> PredicateResult in
-        guard let actual = try expression.evaluate() as? DecodeError else {
+public func beJWTDecodeError(_ code: JWTDecodeError) -> Predicate<Error> {
+     return Predicate<Error>.define("be jwt decode error <\(code)>") { expression, failureMessage -> PredicateResult in
+        guard let actual = try expression.evaluate() as? JWTDecodeError else {
             return PredicateResult(status: .doesNotMatch, message: failureMessage)
         }
         return PredicateResult(bool: actual == code, message: failureMessage)
     }
 }
 
-extension DecodeError: Equatable {}
+extension JWTDecodeError: Equatable {}
 
-public func ==(lhs: DecodeError, rhs: DecodeError) -> Bool {
+public func ==(lhs: JWTDecodeError, rhs: JWTDecodeError) -> Bool {
     return lhs.localizedDescription == rhs.localizedDescription && lhs.errorDescription == rhs.errorDescription
 }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Easily decode a [JWT](https://jwt.io/) and access the claims it contains.
 
-> ⚠️ This library doesn't validate the JWT. Any well formed JWT can be decoded from Base64URL.
+> ⚠️ This library doesn't validate the JWT. Any well-formed JWT can be decoded from Base64URL.
 
 > ⚠️ This library is currently in **First Availability**. We do not recommend using this library in production yet. As we move towards General Availability, please be aware that releases may contain breaking changes.
 
@@ -122,7 +122,7 @@ You can retrieve a custom claim through a subscript and then attempt to convert 
 
 ```swift
 if let email = jwt["email"].string {
-    print("Email in JWT was \(email)")
+    print("Email is \(email)")
 }
 ```
 
@@ -149,11 +149,11 @@ extension JWT {
 
 ### Error Handling
 
-If the JWT is malformed the `decode(jwt:)` function will throw a `DecodeError`.
+If the JWT is malformed the `decode(jwt:)` function will throw a `JWTDecodeError`.
 
 ```swift
-catch let error as DecodeError {
-    error.localizedDescription
+catch let error as JWTDecodeError {
+    print(error)
 }
 ```
 

--- a/V3_MIGRATION_GUIDE.md
+++ b/V3_MIGRATION_GUIDE.md
@@ -9,6 +9,8 @@ As expected with a major release, JWTDecode.swift v3 contains breaking changes. 
   + [Objective-C](#objective-c)
 - [**Supported Platform Versions**](#supported-platform-versions)
 - [**Types Removed**](#types-removed)
+- [**Types Changed**](#types-changed)
+- [**Properties Changed**](#properties-changed)
 
 ## Supported Languages
 
@@ -36,3 +38,11 @@ The built-in ID token validator was removed:
 - `ValidatorJWT` protocol
 - `ValidationError` enum
 - `IDTokenValidation` struct
+
+## Types Changed
+
+The `DecodeError` enum was renamed to `JWTDecodeError`.
+
+## Properties Changed
+
+The `JWTDecodeError.invalidBase64Url` enum case was renamed to `JWTDecodeError.invalidBase64URL`.


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

This PR renames the `DecodeError` enum to `JWTDecodeError`, and renames the error case `invalidBase64Url` to `invalidBase64URL` to better comply with the naming convention used in Foundation types:

<img width="216" alt="Screen Shot 2022-06-16 at 15 15 01" src="https://user-images.githubusercontent.com/5055789/174145972-c575220d-4b28-494a-b503-728d650ddd66.png">

<img width="355" alt="Screen Shot 2022-06-16 at 15 15 20" src="https://user-images.githubusercontent.com/5055789/174146000-55b9677a-3067-495a-b581-f9f1475366ed.png">

### Testing

- [ ] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed