### PR TITLE
Update Gem lockfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.5)
       rexml
-    activesupport (6.1.5)
+    activesupport (6.1.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -17,8 +17,8 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.597.0)
-    aws-sdk-core (3.131.1)
+    aws-partitions (1.600.0)
+    aws-sdk-core (3.131.2)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -155,13 +155,15 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-auth0_shipper (0.4.1)
+      semantic (~> 1.5)
     ffi (1.15.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    google-apis-androidpublisher_v3 (0.21.0)
-      google-apis-core (>= 0.4, < 2.a)
-    google-apis-core (0.5.0)
+    google-apis-androidpublisher_v3 (0.22.0)
+      google-apis-core (>= 0.5, < 2.a)
+    google-apis-core (0.6.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -170,12 +172,12 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    google-apis-iamcredentials_v1 (0.10.0)
-      google-apis-core (>= 0.4, < 2.a)
-    google-apis-playcustomapp_v1 (0.7.0)
-      google-apis-core (>= 0.4, < 2.a)
-    google-apis-storage_v1 (0.14.0)
-      google-apis-core (>= 0.4, < 2.a)
+    google-apis-iamcredentials_v1 (0.12.0)
+      google-apis-core (>= 0.6, < 2.a)
+    google-apis-playcustomapp_v1 (0.9.0)
+      google-apis-core (>= 0.6, < 2.a)
+    google-apis-storage_v1 (0.15.0)
+      google-apis-core (>= 0.5, < 2.a)
     google-cloud-core (1.6.0)
       google-cloud-env (~> 1.0)
       google-cloud-errors (~> 1.0)
@@ -209,7 +211,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    minitest (5.15.0)
+    minitest (5.16.1)
     molinillo (0.8.0)
     multi_json (1.15.0)
     multipart-post (2.0.0)
@@ -233,6 +235,7 @@ GEM
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     security (0.1.3)
+    semantic (1.6.1)
     signet (0.16.1)
       addressable (~> 2.8)
       faraday (>= 0.17.5, < 3.0)
@@ -271,7 +274,7 @@ GEM
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.0)
 
 PLATFORMS
   ruby
@@ -279,6 +282,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods
   fastlane
+  fastlane-plugin-auth0_shipper
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
### Changes

This PR updates the bundle dependencies to their latest version.

@Widcket I noticed Bundler wants to import `fastlane-plugin-auth0_shipper` anytime I do a `bundle update`; is that expected?

### References

N/A

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed