### PR TITLE
Add 3.0.0 fa notice to the master README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ This library will help you check [JWT](https://jwt.io/) payload
 
 > This library doesn't validate the token, any well formed JWT can be decoded from Base64Url.
 
+> 📣 **The [First Availability](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages) release of JWTDecode.swift 3.0.0 is out**
+<br>The GA release is planned for the third week of July. See [#171](https://github.com/auth0/JWTDecode.swift/issues/171) for more information.
+
 ## Table of Contents
 
 - [Requirements](#requirements)


### PR DESCRIPTION
### Changes

This PR adds a notice about the new [3.0.0 fa release](https://github.com/auth0/JWTDecode.swift/releases/tag/3.0.0-fa) to the master README, for better discoverability.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed