### PR TITLE
Fix version number in Podspec

### DIFF
--- a/JWTDecode.podspec
+++ b/JWTDecode.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'JWTDecode'
-  s.version          = '3.0.0-fa'
+  s.version          = '3.0.0'
   s.summary          = 'A JWT decoder for iOS, macOS, tvOS, and watchOS'
   s.description      = <<-DESC
                         Easily decode a JWT and access the claims it contains. 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

This PR bumps the version number in the Podspec, which was not bumped in the [last PR](https://github.com/auth0/JWTDecode.swift/pull/181).
