### PR TITLE
Update Quick and Nimble to latest major

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,4 +138,4 @@ workflows:
           matrix:
             parameters:
               platform: [ios, macos, tvos]
-              xcode: ["13.0.0"]
+              xcode: ['14.2.0']

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 5.0
-github "Quick/Nimble" ~> 10.0
+github "Quick/Quick" ~> 6.0
+github "Quick/Nimble" ~> 12.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v10.0.0"
-github "Quick/Quick" "v5.0.1"
+github "Quick/Nimble" "v12.0.0"
+github "Quick/Quick" "v6.1.0"

--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ let package = Package(
     platforms: [.iOS(.v12), .macOS(.v10_15), .tvOS(.v12), .watchOS("6.2")],
     products: [.library(name: "JWTDecode", targets: ["JWTDecode"])],
     dependencies: [
-        .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "5.0.0")),
-        .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "10.0.0"))
+        .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "6.0.0")),
+        .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "12.0.0"))
     ],
     targets: [
         .target(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,7 +30,7 @@ platform :ios do
 
   desc 'Cocoapods library lint'
   lane :pod_lint do
-    pod_lib_lint(verbose: false, allow_warnings: true)
+    pod_lib_lint(verbose: false, allow_warnings: true, platforms: 'ios,osx,tvos')
   end
 
   desc 'Runs all the tests in a CI environment'


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates the test dependencies [Quick](https://github.com/Quick/Quick) (testing framework) and [Nimble](https://github.com/Quick/Nimble) (matcher library) to their respective latest major version. Quick was updated from **v5.x** to **v6.x**, and Nimble from **v10.x** to **v12.x**.

Also, since latest Quick and Nimble no longer support Xcode 12.x, the CI config was updated to use Xcode 14.x.

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
