### PR TITLE
Use the new syntax for Markdown admonitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-> **Note**
+> [!IMPORTANT]
 > Tests must be added for all new functionality. Existing tests must be updated for all changed/fixed functionality, where applicable. All tests must complete without errors. All new functionality must be documented as well.
 
 ## Environment setup

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Migrating from v2? Check the [Migration Guide](V3_MIGRATION_GUIDE.md).
   + [JWTDecodeError](https://auth0.github.io/JWTDecode.swift/documentation/jwtdecode/jwtdecodeerror)
 - [**Auth0 Documentation**](https://auth0.com/docs) - explore our docs site and learn more about Auth0.
 
-> **Note**
+> [!IMPORTANT]
 > Check the [Support Policy](#support-policy) to learn when dropping Xcode, Swift, and platform versions will not be considered a **breaking change**.
 
 ## Getting Started


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates all the Markdown documentation to use the new admonitions syntax supported by GitHub. The previous syntax is not supported anymore.

<img width="907" alt="Screenshot 2023-12-13 at 16 49 40" src="https://github.com/auth0/Auth0.swift/assets/5055789/bdfba20d-388a-4c82-b380-3dd15362c882">