### PR TITLE
Make `JWTDecodeError` conform to `Sendable`

### DIFF
--- a/JWTDecode/JWTDecodeError.swift
+++ b/JWTDecode/JWTDecodeError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A decoding error due to a malformed JWT.
-public enum JWTDecodeError: LocalizedError, CustomDebugStringConvertible {
+public enum JWTDecodeError: LocalizedError, CustomDebugStringConvertible, Sendable {
     /// When either the header or body parts cannot be Base64URL-decoded.
     case invalidBase64URL(String)
 

--- a/JWTDecodeTests/JWTDecodeSpec.swift
+++ b/JWTDecodeTests/JWTDecodeSpec.swift
@@ -400,7 +400,11 @@ class JWTDecodeSpec: XCTestCase {
     }
 }
 
+#if compiler(>=6.0)
 extension JWTDecodeError: @retroactive Equatable {}
+#else
+extension JWTDecodeError: Equatable {}
+#endif
 
 public func ==(lhs: JWTDecodeError, rhs: JWTDecodeError) -> Bool {
     return lhs.localizedDescription == rhs.localizedDescription && lhs.errorDescription == rhs.errorDescription

--- a/JWTDecodeTests/JWTDecodeSpec.swift
+++ b/JWTDecodeTests/JWTDecodeSpec.swift
@@ -3,51 +3,51 @@ import JWTDecode
 import Foundation
 
 class JWTDecodeSpec: XCTestCase {
-    
+
     func testExpiredJWT() {
         let sut = expiredJWT()
         XCTAssertTrue(sut.expired)
     }
-    
+
     func testNonExpiredJWT() {
         let sut = nonExpiredJWT()
         XCTAssertFalse(sut.expired)
     }
-    
+
     func testExpiredJWTWithCloseEnoughTimestamp() {
         let sut = jwtThatExpiresAt(date: Date())
         XCTAssertTrue(sut.expired)
     }
-    
+
     func testObtainPayload() {
         let jwt = jwt(withBody: ["sub": "myid", "name": "Shawarma Monk"])
         let payload = jwt.body as! [String: String]
         XCTAssertEqual(payload, ["sub": "myid", "name": "Shawarma Monk"])
     }
-    
+
     func testReturnOriginalJWTStringRepresentation() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjb20uc29td2hlcmUuZmFyLmJleW9uZDphcGki"
         + "LCJpc3MiOiJhdXRoMCIsInVzZXJfcm9sZSI6ImFkbWluIn0.sS84motSLj9HNTgrCPcAjgZIQ99jXNN7_W9fEIIfxz0"
         let jwt = try! decode(jwt: jwtString)
         XCTAssertEqual(jwt.string, jwtString)
     }
-    
+
     func testReturnExpireDate() {
         let sut = expiredJWT()
         XCTAssertNotNil(sut.expiresAt)
     }
-    
+
     func testDecodeValidJWT() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJjb20uc29td2hlcmUuZmFyLmJleW9uZDphcGki"
         + "LCJpc3MiOiJhdXRoMCIsInVzZXJfcm9sZSI6ImFkbWluIn0.sS84motSLj9HNTgrCPcAjgZIQ99jXNN7_W9fEIIfxz0"
         XCTAssertNotNil(try! decode(jwt: jwtString))
     }
-    
+
     func testDecodeValidJWTWithEmptyJSONBody() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.Et9HFtf9R3GEMA0IICOfFMVXY7kkTX1wr4qCyhIf58U"
         XCTAssertNotNil(try! decode(jwt: jwtString))
     }
-    
+
     func testRaiseExceptionWithInvalidBase64Encoding() {
         let invalidChar = "%"
         let jwtString = "\(invalidChar).BODY.SIGNATURE"
@@ -55,60 +55,60 @@ class JWTDecodeSpec: XCTestCase {
             XCTAssertEqual(error as? JWTDecodeError, .invalidBase64URL(invalidChar))
         }
     }
-    
+
     func testRaiseExceptionWithInvalidJSONInJWT() {
         let jwtString = "HEADER.BODY.SIGNATURE"
         XCTAssertThrowsError(try decode(jwt: jwtString)) { error in
             XCTAssertEqual(error as? JWTDecodeError, .invalidJSON("HEADER"))
         }
     }
-    
+
     func testRaiseExceptionWithMissingParts() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdWIifQ"
         XCTAssertThrowsError(try decode(jwt: jwtString)) { error in
             XCTAssertEqual(error as? JWTDecodeError, .invalidPartCount(jwtString, 2))
         }
     }
-    
+
     func testReturnHeader() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdWIifQ.xXcD7WOvUDHJ94E6aVHYgXdsJHLl2oW7Z"
         + "Xm4QpVvXnY"
         let sut = try! decode(jwt: jwtString)
         XCTAssertEqual(sut.header as? [String: String], ["alg": "HS256", "typ": "JWT"])
     }
-    
+
     func testReturnBody() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdWIifQ.xXcD7WOvUDHJ94E6aVHYgXdsJHLl2oW7Z"
         + "Xm4QpVvXnY"
         let sut = try! decode(jwt: jwtString)
         XCTAssertEqual(sut.body as? [String: String], ["sub": "sub"])
     }
-    
+
     func testReturnSignature() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdWIifQ.xXcD7WOvUDHJ94E6aVHYgXdsJHLl2oW7Z"
         + "Xm4QpVvXnY"
         let sut = try! decode(jwt: jwtString)
         XCTAssertEqual(sut.signature, "xXcD7WOvUDHJ94E6aVHYgXdsJHLl2oW7ZXm4QpVvXnY")
     }
-    
+
     func testExpiresAtClaimExpiredJWT() {
         let sut = expiredJWT()
         XCTAssertNotNil(sut.expiresAt)
         XCTAssertTrue(sut.expired)
     }
-    
+
     func testExpiresAtClaimNonExpiredJWT() {
         let sut = nonExpiredJWT()
         XCTAssertNotNil(sut.expiresAt)
         XCTAssertFalse(sut.expired)
     }
-    
+
     func testExpiresAtClaimJWTWithoutExpiresAtClaim() {
         let sut = jwt(withBody: ["sub": UUID().uuidString])
         XCTAssertNil(sut.expiresAt)
         XCTAssertFalse(sut.expired)
     }
-    
+
     func testIssuerClaim() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUudXMuYXV0aDAuY29t"
         + "Iiwic3ViIjoiYXV0aDB8MTAxMDEwMTAxMCIsImF1ZCI6Imh0dHBzOi8vZXhhbXBsZS51cy5hdXRoMC5jb20iLCJleHAiOjE"
@@ -117,7 +117,7 @@ class JWTDecodeSpec: XCTestCase {
         let sut = try! decode(jwt: jwtString)
         XCTAssertEqual(sut.issuer, "https://example.us.auth0.com")
     }
-    
+
     func testSubjectClaim() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUudXMuYXV0aDAuY29t"
         + "Iiwic3ViIjoiYXV0aDB8MTAxMDEwMTAxMCIsImF1ZCI6Imh0dHBzOi8vZXhhbXBsZS51cy5hdXRoMC5jb20iLCJleHAiOjE"
@@ -126,7 +126,7 @@ class JWTDecodeSpec: XCTestCase {
         let sut = try! decode(jwt: jwtString)
         XCTAssertEqual(sut.subject, "auth0|1010101010")
     }
-    
+
     func testSingleAudienceClaim() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUudXMuYXV0aDAuY29t"
         + "Iiwic3ViIjoiYXV0aDB8MTAxMDEwMTAxMCIsImF1ZCI6Imh0dHBzOi8vZXhhbXBsZS51cy5hdXRoMC5jb20iLCJleHAiOjE"
@@ -135,7 +135,7 @@ class JWTDecodeSpec: XCTestCase {
         let sut = try! decode(jwt: jwtString)
         XCTAssertEqual(sut.audience, ["https://example.us.auth0.com"])
     }
-    
+
     func testMultipleAudiencesClaim() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsiaHR0cHM6Ly9leGFtcGxlLnVzLmF1dGgw"
         + "LmNvbSIsImh0dHBzOi8vYXBpLmV4YW1wbGUudXMuYXV0aDAuY29tIl19.sw24la9mmCmykudpyE-U1Ar5bbyuDMyKaW"
@@ -143,7 +143,7 @@ class JWTDecodeSpec: XCTestCase {
         let sut = try! decode(jwt: jwtString)
         XCTAssertEqual(sut.audience, ["https://example.us.auth0.com", "https://api.example.us.auth0.com"])
     }
-    
+
     func testIssuedAtClaim() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUudXMuYXV0aDAuY29t"
         + "Iiwic3ViIjoiYXV0aDB8MTAxMDEwMTAxMCIsImF1ZCI6Imh0dHBzOi8vZXhhbXBsZS51cy5hdXRoMC5jb20iLCJleHAiOjE"
@@ -152,7 +152,7 @@ class JWTDecodeSpec: XCTestCase {
         let sut = try! decode(jwt: jwtString)
         XCTAssertEqual(sut.issuedAt, Date(timeIntervalSince1970: 1372638336))
     }
-    
+
     func testNotBeforeClaim() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUudXMuYXV0aDAuY29t"
         + "Iiwic3ViIjoiYXV0aDB8MTAxMDEwMTAxMCIsImF1ZCI6Imh0dHBzOi8vZXhhbXBsZS51cy5hdXRoMC5jb20iLCJleHAiOjE"
@@ -161,7 +161,7 @@ class JWTDecodeSpec: XCTestCase {
         let sut = try! decode(jwt: jwtString)
         XCTAssertEqual(sut.notBefore, Date(timeIntervalSince1970: 1372638336))
     }
-    
+
     func testJWTIdClaim() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUudXMuYXV0aDAuY29t"
         + "Iiwic3ViIjoiYXV0aDB8MTAxMDEwMTAxMCIsImF1ZCI6Imh0dHBzOi8vZXhhbXBsZS51cy5hdXRoMC5jb20iLCJleHAiOjE"
@@ -170,7 +170,7 @@ class JWTDecodeSpec: XCTestCase {
         let sut = try! decode(jwt: jwtString)
         XCTAssertEqual(sut.identifier, "qwerty123456")
     }
-    
+
     func testClaimByName() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -181,7 +181,7 @@ class JWTDecodeSpec: XCTestCase {
         let claim = sut.claim(name: "custom_string_claim")
         XCTAssertNotNil(claim.rawValue)
     }
-    
+
     func testCustomStringClaim() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -198,7 +198,7 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertNil(claim.date)
         XCTAssertNil(claim.boolean)
     }
-    
+
     func testCustomIntegerClaim() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -214,7 +214,7 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertEqual(claim.date, Date(timeIntervalSince1970: 10))
         XCTAssertNil(claim.boolean)
     }
-    
+
     func testCustomIntegerClaim0() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -230,7 +230,7 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertEqual(claim.date, Date(timeIntervalSince1970: 0))
         XCTAssertNil(claim.boolean)
     }
-    
+
     func testCustomIntegerClaim1() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -246,7 +246,7 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertEqual(claim.date, Date(timeIntervalSince1970: 1))
         XCTAssertNil(claim.boolean)
     }
-    
+
     func testCustomIntegerClaimString() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -262,7 +262,7 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertEqual(claim.date, Date(timeIntervalSince1970: 13))
         XCTAssertNil(claim.boolean)
     }
-    
+
     func testCustomDoubleClaim() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -279,7 +279,7 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertEqual(claim.date, Date(timeIntervalSince1970: 3.1))
         XCTAssertNil(claim.boolean)
     }
-    
+
     func testCustomDoubleClaim0() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -296,7 +296,7 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertEqual(claim.date, Date(timeIntervalSince1970: 0))
         XCTAssertNil(claim.boolean)
     }
-    
+
     func testCustomDoubleClaim1() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -313,7 +313,7 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertEqual(claim.date, Date(timeIntervalSince1970: 1))
         XCTAssertNil(claim.boolean)
     }
-    
+
     func testCustomDoubleClaimString() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -330,7 +330,7 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertEqual(claim.date, Date(timeIntervalSince1970: 1.3))
         XCTAssertNil(claim.boolean)
     }
-    
+
     func testCustomBooleanClaimTrue() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -347,7 +347,7 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertNil(claim.date)
         XCTAssertEqual(claim.boolean, true)
     }
-    
+
     func testCustomBooleanClaimFalse() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -364,7 +364,7 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertNil(claim.date)
         XCTAssertEqual(claim.boolean, false)
     }
-    
+
     func testMissingClaim() {
         let sut = jwt(withBody: ["sub": UUID().uuidString,
                                  "custom_string_claim": "Shawarma Friday!",
@@ -380,21 +380,27 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertNil(unknownClaim.date)
         XCTAssertNil(unknownClaim.boolean)
     }
-    
+
     func testRawClaimEmail() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3NhbXBsZXMuYXV0aDAuY29tIiwic3ViIjoiYXV0aDB8MTAxMDEwMTAxMCIsImF1ZCI6Imh0dHBzOi8vc2FtcGxlcy5hdXRoMC5jb20iLCJleHAiOjEzNzI2NzQzMzYsImlhdCI6MTM3MjYzODMzNiwianRpIjoicXdlcnR5MTIzNDU2IiwibmJmIjoxMzcyNjM4MzM2LCJlbWFpbCI6InVzZXJAaG9zdC5jb20iLCJjdXN0b20iOlsxLDIsM119.JeMRyHLkcoiqGxd958B6PABKNvhOhIgw-kbjecmhR_E"
         let sut = try! decode(jwt: jwtString)
-        XCTAssertEqual(sut["email"].string, "user@host.com")
+        XCTAssertEqual(sut["email"].rawValue as? String, "user@host.com")
     }
-    
+
     func testRawClaimArray() {
         let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3NhbXBsZXMuYXV0aDAuY29tIiwic3ViIjoiYXV0aDB8MTAxMDEwMTAxMCIsImF1ZCI6Imh0dHBzOi8vc2FtcGxlcy5hdXRoMC5jb20iLCJleHAiOjEzNzI2NzQzMzYsImlhdCI6MTM3MjYzODMzNiwianRpIjoicXdlcnR5MTIzNDU2IiwibmJmIjoxMzcyNjM4MzM2LCJlbWFpbCI6InVzZXJAaG9zdC5jb20iLCJjdXN0b20iOlsxLDIsM119.JeMRyHLkcoiqGxd958B6PABKNvhOhIgw-kbjecmhR_E"
         let sut = try! decode(jwt: jwtString)
         XCTAssertNotNil(sut["custom"].rawValue as? [Int])
     }
+
+    func testRawClaimDict() {
+        let jwtString = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3NhbXBsZXMuYXV0aDAuY29tIiwic3ViIjoiYXV0aDB8MTAxMDEwMTAxMCIsImF1ZCI6Imh0dHBzOi8vc2FtcGxlcy5hdXRoMC5jb20iLCJleHAiOjEzNzI2NzQzMzYsImlhdCI6MTM3MjYzODMzNiwianRpIjoicXdlcnR5MTIzNDU2IiwibmJmIjoxMzcyNjM4MzM2LCJlbWFpbCI6InVzZXJAaG9zdC5jb20iLCJjdXN0b20iOnsiZm9vIjoiYmFyIiwiYmF6IjoxMjN9fQ.scStGGBQrySWIeJEoCgHhx7fUQT-ciUGG_itliv1nKQ"
+        let sut = try! decode(jwt: jwtString)
+        XCTAssertNotNil(sut["custom"].rawValue as? [String: Any])
+    }
 }
 
-extension JWTDecodeError: Equatable {}
+extension JWTDecodeError: @retroactive Equatable {}
 
 public func ==(lhs: JWTDecodeError, rhs: JWTDecodeError) -> Bool {
     return lhs.localizedDescription == rhs.localizedDescription && lhs.errorDescription == rhs.errorDescription


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [X] All new/changed/fixed functionality is covered by tests (or N/A)
- [X] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR makes the `JWTDecodeError` error conform to `Sendable`, for better compatibility with Swift 6.

Also, a missing test case was added and an incorrect assert was fixed.

### 🎯 Testing

N/A
