### PR TITLE
Add support for expiration leeway

### DIFF
--- a/JWTDecode/JWT.swift
+++ b/JWTDecode/JWT.swift
@@ -46,6 +46,13 @@ public protocol JWT {
     /// deemed unexpired.
     var expired: Bool { get }
 
+    /// Checks if the JWT will expire in the given time period (in seconds) using the `exp` claim.  If the claim is not
+    /// present the JWT will be deemed to not expire.
+    ///
+    /// - Parameter seconds: Time period in seconds.
+    /// - Returns: Whether the JWT will expire in the given time period or not.
+    func expires(in seconds: Int) -> Bool
+
 }
 
 public extension JWT {

--- a/JWTDecode/JWTDecode.swift
+++ b/JWTDecode/JWTDecode.swift
@@ -48,11 +48,22 @@ struct DecodedJWT: JWT {
     var identifier: String? { return claim(name: "jti").string }
 
     var expired: Bool {
+        return self.expires(before: Date())
+    }
+
+    func expires(in seconds: Int) -> Bool {
+        let expireDate = Date(timeIntervalSinceNow: TimeInterval(seconds))
+        return self.expires(before: expireDate)
+    }
+
+    func expires(before expireDate: Date) -> Bool {
         guard let date = self.expiresAt else {
             return false
         }
-        return date.compare(Date()) != ComparisonResult.orderedDescending
+
+        return date.compare(expireDate) != ComparisonResult.orderedDescending
     }
+
 }
 
 /// A JWT claim.

--- a/JWTDecodeTests/JWTDecodeSpec.swift
+++ b/JWTDecodeTests/JWTDecodeSpec.swift
@@ -18,7 +18,17 @@ class JWTDecodeSpec: XCTestCase {
         let sut = jwtThatExpiresAt(date: Date())
         XCTAssertTrue(sut.expired)
     }
-    
+
+    func testJWTWillExpire() {
+        let sut = jwtThatExpiresAt(date: Date().addingTimeInterval(500))
+        XCTAssertTrue(sut.expires(in: 600))
+    }
+
+    func testJWTWillNotExpire() {
+        let sut = jwtThatExpiresAt(date: Date().addingTimeInterval(500))
+        XCTAssertFalse(sut.expires(in: 400))
+    }
+
     func testObtainPayload() {
         let jwt = jwt(withBody: ["sub": "myid", "name": "Shawarma Monk"])
         let payload = jwt.body as! [String: String]


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR adds a new public `expires(in:)` method that checks if the JWT will expire in the given time period (in seconds) using the `exp` claim.

Support for expiration leeway [is already available](https://github.com/auth0/JWTDecode.Android/blob/ec4b54496e684c5fb9e65f5ebb36e6241ef46161/lib/src/main/java/com/auth0/android/jwt/JWT.java#L161-L171) in [JWTDecode.Android](https://github.com/auth0/JWTDecode.Android).

### 📎 References

Closes https://github.com/auth0/JWTDecode.swift/issues/221

### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
