### PR TITLE
Use strict JWT part decoding and redacted errors

### DIFF
--- a/JWTDecode/JWTDecode.swift
+++ b/JWTDecode/JWTDecode.swift
@@ -201,7 +201,7 @@ private func base64UrlDecode(_ value: String) -> Data? {
         let padding = "".padding(toLength: Int(paddingLength), withPad: "=", startingAt: 0)
         base64 += padding
     }
-    return Data(base64Encoded: base64, options: .ignoreUnknownCharacters)
+    return Data(base64Encoded: base64)
 }
 
 private func decodeJWTPart(_ value: String) throws -> [String: any Sendable] {

--- a/JWTDecode/JWTDecodeError.swift
+++ b/JWTDecode/JWTDecodeError.swift
@@ -29,12 +29,12 @@ public enum JWTDecodeError: LocalizedError, CustomDebugStringConvertible, Sendab
     /// - Important: You should avoid displaying the error description to the user, it's meant for **debugging** only.
     public var debugDescription: String {
         switch self {
-        case .invalidJSON(let value):
-            return "Failed to parse JSON from Base64URL value \(value)."
-        case .invalidPartCount(let jwt, let parts):
-            return "The JWT \(jwt) has \(parts) parts when it should have 3 parts."
-        case .invalidBase64URL(let value):
-            return "Failed to decode Base64URL value \(value)."
+        case .invalidJSON:
+            return "Failed to parse JSON from a Base64URL JWT part."
+        case .invalidPartCount(_, let parts):
+            return "The JWT has \(parts) parts when it should have 3 parts."
+        case .invalidBase64URL:
+            return "Failed to decode a Base64URL JWT part."
         case .claimDecodingFailed(let message):
             return "Failed to decode claim: \(message)"
         }

--- a/JWTDecodeTests/JWTDecodeSpec.swift
+++ b/JWTDecodeTests/JWTDecodeSpec.swift
@@ -66,6 +66,13 @@ class JWTDecodeSpec: XCTestCase {
         }
     }
 
+    func testInvalidBase64WithIgnoredCharactersIsRejected() {
+        let jwtString = "eyJhbGciOiJIUzI1NiJ%.e30.SIGNATURE"
+        XCTAssertThrowsError(try decode(jwt: jwtString)) { error in
+            XCTAssertEqual(error as? JWTDecodeError, .invalidBase64URL("eyJhbGciOiJIUzI1NiJ%"))
+        }
+    }
+
     func testRaiseExceptionWithInvalidJSONInJWT() {
         let jwtString = "HEADER.BODY.SIGNATURE"
         XCTAssertThrowsError(try decode(jwt: jwtString)) { error in
@@ -78,6 +85,15 @@ class JWTDecodeSpec: XCTestCase {
         XCTAssertThrowsError(try decode(jwt: jwtString)) { error in
             XCTAssertEqual(error as? JWTDecodeError, .invalidPartCount(jwtString, 2))
         }
+    }
+
+    func testErrorDescriptionsDoNotExposeJWTContents() {
+        let jwtString = "header.payload.signature"
+        let encodedPart = "eyJzdWIiOiJzZWNyZXQifQ"
+
+        XCTAssertFalse(JWTDecodeError.invalidPartCount(jwtString, 3).localizedDescription.contains(jwtString))
+        XCTAssertFalse(JWTDecodeError.invalidJSON(encodedPart).localizedDescription.contains(encodedPart))
+        XCTAssertFalse(JWTDecodeError.invalidBase64URL(encodedPart).localizedDescription.contains(encodedPart))
     }
 
     func testReturnHeader() {


### PR DESCRIPTION
## Summary
- reject JWT Base64URL parts with unexpected characters instead of ignoring them
- avoid echoing JWT strings or encoded JWT parts in error descriptions
- add tests for strict decoding and redacted error descriptions

## Validation
- Not run locally: Swift toolchain is not installed on this Windows machine.
- Local checkout note: generated docs contain Windows-invalid paths, so the source was inspected from an archive excluding docs.